### PR TITLE
update for compatibility with draft-js 0.11.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,23 +69,12 @@ const richButtonsPlugin = () => {
       };
     },
 
-    handleKeyCommand: (command, state, { getEditorState, setEditorState }) => {
-      const editorState = getEditorState();
-      const newState = RichUtils.handleKeyCommand(editorState, command);
-      if (newState) {
-        setEditorState(newState);
-        return true;
-      }
-      return false;
+    handleKeyCommand: (editorState, command) => {
+      return RichUtils.handleKeyCommand(editorState, command);
     },
 
-    onTab: (event, { getEditorState, setEditorState }) => {
-      const editorState = getEditorState();
-      const newState = RichUtils.onTab(event, editorState, MAX_LIST_DEPTH);
-
-      if (newState !== editorState) {
-        setEditorState(newState);
-      }
+    onTab: (event, editor) => {
+      return RichUtils.onTab(event, editor.getEditorState(), MAX_LIST_DEPTH);
     },
 
     onChange: (newState) => store.onChange(newState)


### PR DESCRIPTION
Update the `handleKeyCommand` and `onTab` functions to make them compatible with the latest versions of draft-js and @draft-js-plugins/editor (0.11.7 and 4.1.0 at the time of this writing). I believe, but have not tested, that this fix should also work for more recent versions of the deprecated `draft-js-plugins-editor`.